### PR TITLE
Gitlab connector including wrong namespace

### DIFF
--- a/Open-Connectors/ava-tax/ava_tax.py
+++ b/Open-Connectors/ava-tax/ava_tax.py
@@ -3,7 +3,7 @@ import os
 from typing import Any, Dict, List
 
 from avalara import AvataxClient
-from authomize.rest_api_client.generated.schemas import (
+from authomize.rest_api_client.generated.connectors_rest_api.schemas import (
     AccessTypes,
     AssetTypes,
     UserStatus,

--- a/Open-Connectors/net-suite/net_suite.py
+++ b/Open-Connectors/net-suite/net_suite.py
@@ -2,7 +2,7 @@
 import os
 from typing import Any, Dict, List
 
-from authomize.rest_api_client.generated.schemas import (
+from authomize.rest_api_client.generated.connectors_rest_api.schemas import (
     AccessTypes,
     AssetTypes,
     UserStatus,

--- a/Open-Connectors/tenable/tenable.py
+++ b/Open-Connectors/tenable/tenable.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 
 from tenable.io import TenableIO
 
-from authomize.rest_api_client.generated.schemas import (
+from authomize.rest_api_client.generated.connectors_rest_api.schemas import (
     AccessTypes,
     AssetTypes,
     UserStatus,

--- a/Open-Connectors/xactly-incent/xactly_incent.py
+++ b/Open-Connectors/xactly-incent/xactly_incent.py
@@ -2,7 +2,7 @@
 import os
 
 import requests
-from authomize.rest_api_client.generated.schemas import (
+from authomize.rest_api_client.generated.connectors_rest_api.schemas import (
     AccessTypes,
     AssetTypes,
     UserStatus,

--- a/Open-Connectors/zuora/zuora.py
+++ b/Open-Connectors/zuora/zuora.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from typing import Dict, Any
 
 import requests
-from authomize.rest_api_client.generated.schemas import (
+from authomize.rest_api_client.generated.connectors_rest_api.schemas import (
     AccessTypes,
     AssetTypes,
     UserStatus,


### PR DESCRIPTION
Issue #37 The connectors from the GitLab Authomize Repository which have been copied over to the Open-ITDR/Connectors folder are including the authomize.rest_api_client.generated.schemas namespace but should be including the authomize.rest_api_client.generated.connectors_rest_api.schemas namespace from the connectors-rest-api-client repository.